### PR TITLE
Allow passing Object values to runconfigs & Excluding additional directories

### DIFF
--- a/subprojects/common/src/main/java/net/covers1624/wt/api/script/runconfig/RunConfig.java
+++ b/subprojects/common/src/main/java/net/covers1624/wt/api/script/runconfig/RunConfig.java
@@ -5,8 +5,6 @@
  */
 package net.covers1624.wt.api.script.runconfig;
 
-import org.jetbrains.annotations.Nullable;
-
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -109,8 +107,4 @@ public interface RunConfig {
      * @return Gets the System Properties for this RunConfiguration.
      */
     Map<String, String> getSysProps();
-
-    static String toString(@Nullable Object obj) {
-        return obj == null ? "" : obj.toString();
-    }
 }

--- a/subprojects/common/src/main/java/net/covers1624/wt/api/script/runconfig/RunConfig.java
+++ b/subprojects/common/src/main/java/net/covers1624/wt/api/script/runconfig/RunConfig.java
@@ -5,6 +5,8 @@
  */
 package net.covers1624.wt.api.script.runconfig;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -35,7 +37,7 @@ public interface RunConfig {
      *
      * @param args The Arguments.
      */
-    default void vmArg(String... args) {
+    default void vmArg(Object... args) {
         vmArg(Arrays.asList(args));
     }
 
@@ -44,7 +46,7 @@ public interface RunConfig {
      *
      * @param args The Arguments.
      */
-    void vmArg(List<String> args);
+    void vmArg(List<Object> args);
 
     /**
      * @return Gets the Vm Arguments.
@@ -56,7 +58,7 @@ public interface RunConfig {
      *
      * @param args The Arguments.
      */
-    default void progArg(String... args) {
+    default void progArg(Object... args) {
         progArg(Arrays.asList(args));
     }
 
@@ -65,7 +67,7 @@ public interface RunConfig {
      *
      * @param args The Arguments.
      */
-    void progArg(List<String> args);
+    void progArg(List<Object> args);
 
     /**
      * @return Gets the VmArguments.
@@ -89,7 +91,7 @@ public interface RunConfig {
      *
      * @param vars The variables.
      */
-    void envVar(Map<String, String> vars);
+    void envVar(Map<String, Object> vars);
 
     /**
      * @return Gets the Environment Variables for this RunConfiguration.
@@ -101,11 +103,14 @@ public interface RunConfig {
      *
      * @param props The properties.
      */
-    void sysProp(Map<String, String> props);
+    void sysProp(Map<String, Object> props);
 
     /**
      * @return Gets the System Properties for this RunConfiguration.
      */
     Map<String, String> getSysProps();
-}
 
+    static String toString(@Nullable Object obj) {
+        return obj == null ? "" : obj.toString();
+    }
+}

--- a/subprojects/core/src/main/java/net/covers1624/wt/WorkspaceTool.java
+++ b/subprojects/core/src/main/java/net/covers1624/wt/WorkspaceTool.java
@@ -306,7 +306,13 @@ public class WorkspaceTool {
         });
 
         // add run directories as excluded paths for every module
-        context.workspaceScript.getWorkspace().getRunConfigContainer().getRunConfigs().values().stream().map(RunConfig::getRunDir).forEach(path -> allModules.forEach(module -> module.addExclude(path)));
+        context.workspaceScript.getWorkspace().getRunConfigContainer().getRunConfigs().values().stream()
+                               .map(RunConfig::getRunDir)
+                               .forEach(path ->
+                                       allModules.forEach(module ->
+                                               module.addExclude(path)
+                                       )
+                               );
 
         ProcessModulesEvent.REGISTRY.fireEvent(new ProcessModulesEvent(context));
 

--- a/subprojects/core/src/main/java/net/covers1624/wt/WorkspaceTool.java
+++ b/subprojects/core/src/main/java/net/covers1624/wt/WorkspaceTool.java
@@ -305,6 +305,9 @@ public class WorkspaceTool {
             }
         });
 
+        // add run directories as excluded paths for every module
+        context.workspaceScript.getWorkspace().getRunConfigContainer().getRunConfigs().values().stream().map(RunConfig::getRunDir).forEach(path -> allModules.forEach(module -> module.addExclude(path)));
+
         ProcessModulesEvent.REGISTRY.fireEvent(new ProcessModulesEvent(context));
 
         stream(allModules.spliterator(), true).forEach(context.dependencyLibrary::consume);

--- a/subprojects/core/src/main/java/net/covers1624/wt/api/impl/script/runconfig/DefaultRunConfig.java
+++ b/subprojects/core/src/main/java/net/covers1624/wt/api/impl/script/runconfig/DefaultRunConfig.java
@@ -6,6 +6,7 @@
 package net.covers1624.wt.api.impl.script.runconfig;
 
 import net.covers1624.wt.api.script.runconfig.RunConfig;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -28,15 +29,19 @@ public class DefaultRunConfig implements RunConfig {
     //@formatter:off
     @Override public void mainClass(String name) { mainClass = name; }
     @Override public String getMainClass() { return mainClass; }
-    @Override public void vmArg(List<Object> args) { args.stream().map(RunConfig::toString).forEach(vmArgs::add); }
+    @Override public void vmArg(List<Object> args) { args.stream().map(DefaultRunConfig::toString).forEach(vmArgs::add); }
     @Override public List<String> getVmArgs() { return vmArgs; }
-    @Override public void progArg(List<Object> args) { args.stream().map(RunConfig::toString).forEach(progArgs::add); }
+    @Override public void progArg(List<Object> args) { args.stream().map(DefaultRunConfig::toString).forEach(progArgs::add); }
     @Override public List<String> getProgArgs() { return progArgs; }
     @Override public void runDir(Path path) { runDir = path; }
     @Override public Path getRunDir() { return runDir; }
-    @Override public void envVar(Map<String, Object> vars) { vars.forEach((key, value) -> envVars.put(key, RunConfig.toString(value))); }
+    @Override public void envVar(Map<String, Object> vars) { vars.forEach((key, value) -> envVars.put(key, DefaultRunConfig.toString(value))); }
     @Override public Map<String, String> getEnvVars() { return envVars; }
-    @Override public void sysProp(Map<String, Object> props) { props.forEach((key, value) -> sysProps.put(key, RunConfig.toString(value))); }
+    @Override public void sysProp(Map<String, Object> props) { props.forEach((key, value) -> sysProps.put(key, DefaultRunConfig.toString(value))); }
     @Override public Map<String, String> getSysProps() { return sysProps; }
     //@formatter:on
+
+    public static String toString(@Nullable Object obj) {
+        return obj == null ? "" : obj.toString();
+    }
 }

--- a/subprojects/core/src/main/java/net/covers1624/wt/api/impl/script/runconfig/DefaultRunConfig.java
+++ b/subprojects/core/src/main/java/net/covers1624/wt/api/impl/script/runconfig/DefaultRunConfig.java
@@ -28,15 +28,15 @@ public class DefaultRunConfig implements RunConfig {
     //@formatter:off
     @Override public void mainClass(String name) { mainClass = name; }
     @Override public String getMainClass() { return mainClass; }
-    @Override public void vmArg(List<String> args) { vmArgs.addAll(args); }
+    @Override public void vmArg(List<Object> args) { args.stream().map(RunConfig::toString).forEach(vmArgs::add); }
     @Override public List<String> getVmArgs() { return vmArgs; }
-    @Override public void progArg(List<String> args) { progArgs.addAll(args); }
+    @Override public void progArg(List<Object> args) { args.stream().map(RunConfig::toString).forEach(progArgs::add); }
     @Override public List<String> getProgArgs() { return progArgs; }
     @Override public void runDir(Path path) { runDir = path; }
     @Override public Path getRunDir() { return runDir; }
-    @Override public void envVar(Map<String, String> vars) { envVars.putAll(vars); }
+    @Override public void envVar(Map<String, Object> vars) { vars.forEach((key, value) -> envVars.put(key, RunConfig.toString(value))); }
     @Override public Map<String, String> getEnvVars() { return envVars; }
-    @Override public void sysProp(Map<String, String> props) { sysProps.putAll(props); }
+    @Override public void sysProp(Map<String, Object> props) { props.forEach((key, value) -> sysProps.put(key, RunConfig.toString(value))); }
     @Override public Map<String, String> getSysProps() { return sysProps; }
     //@formatter:on
 }

--- a/subprojects/forge/src/main/java/net/covers1624/wt/forge/Forge114Extension.java
+++ b/subprojects/forge/src/main/java/net/covers1624/wt/forge/Forge114Extension.java
@@ -57,7 +57,7 @@ public class Forge114Extension extends AbstractForge113PlusExtension {
         GradleBackedModule forgeModule = findForgeRootModule(context);
         ProjectData rootProject = forgeModule.getProjectData();
         ProjectData forgeSubProject = requireNonNull(rootProject.subProjects.get("forge"), "Missing forge submodule.");
-        Map<String, String> envVars = new HashMap<>();
+        Map<String, Object> envVars = new HashMap<>();
         String mcVersion = rootProject.extraProperties.get("MC_VERSION");
         VersionInfoJson versionInfo = requireNonNull(context.blackboard.get(VERSION_INFO));
 
@@ -115,7 +115,7 @@ public class Forge114Extension extends AbstractForge113PlusExtension {
         //TODO, generate AccessList.
 
         List<String> modClasses = buildModClasses(context, exportedData);
-        Map<String, String> envVars = Collections.singletonMap("MOD_CLASSES", Strings.join(modClasses, File.pathSeparatorChar));
+        Map<String, Object> envVars = Collections.singletonMap("MOD_CLASSES", Strings.join(modClasses, File.pathSeparatorChar));
         for (RunConfig runConfig : context.workspaceScript.getWorkspace().getRunConfigContainer().getRunConfigs().values()) {
             runConfig.envVar(envVars);
         }

--- a/subprojects/forge/src/main/java/net/covers1624/wt/forge/Forge117Extension.java
+++ b/subprojects/forge/src/main/java/net/covers1624/wt/forge/Forge117Extension.java
@@ -123,11 +123,11 @@ public class Forge117Extension extends AbstractForge113PlusExtension {
                 "--fml.mcpVersion", rootProject.extraProperties.get("MCP_VERSION")
         );
 
-        Map<String, String> envVars = new HashMap<>();
+        Map<String, Object> envVars = new HashMap<>();
         envVars.put("FORGE_SPEC", forgeSubProject.extraProperties.get("SPEC_VERSION"));
         envVars.put("LAUNCHER_VERSION", forgeSubProject.extraProperties.get("SPEC_VERSION"));
 
-        Map<String, String> sysProps = new HashMap<>();
+        Map<String, Object> sysProps = new HashMap<>();
         sysProps.put("eventbus.checkTypesOnDispatch", "true");
 
         sysProps.put("legacyClassPath", String.join(File.pathSeparator, runtimeClasspath));

--- a/subprojects/intellij/src/main/groovy/net/covers1624/wt/intellij/IntellijWorkspaceHandler.groovy
+++ b/subprojects/intellij/src/main/groovy/net/covers1624/wt/intellij/IntellijWorkspaceHandler.groovy
@@ -28,7 +28,9 @@ class IntellijWorkspaceHandler implements WorkspaceHandler<Intellij> {
         topLevelModule.isGroup = true
         topLevelModule.name = context.projectDir.getFileName().toString()
         topLevelModule.output = outFolder.resolve(topLevelModule.name.replace(".", "_"))
-        topLevelModule.excludes = [context.projectDir.resolve(".idea"), context.projectDir.resolve(".workspace_tool")]
+	    workspace.excludeDirs.stream().map(context.projectDir::resolve).forEach(topLevelModule.excludes::add)
+        topLevelModule.excludes.add(context.projectDir.resolve(".idea"))
+        topLevelModule.excludes.add(context.projectDir.resolve(".workspace_tool"))
         modules[topLevelModule.name] = topLevelModule
 
         context.allModules.each { module ->

--- a/subprojects/intellij/src/main/groovy/net/covers1624/wt/intellij/IntellijWorkspaceHandler.groovy
+++ b/subprojects/intellij/src/main/groovy/net/covers1624/wt/intellij/IntellijWorkspaceHandler.groovy
@@ -28,7 +28,9 @@ class IntellijWorkspaceHandler implements WorkspaceHandler<Intellij> {
         topLevelModule.isGroup = true
         topLevelModule.name = context.projectDir.getFileName().toString()
         topLevelModule.output = outFolder.resolve(topLevelModule.name.replace(".", "_"))
-	    workspace.excludeDirs.stream().map(context.projectDir::resolve).forEach(topLevelModule.excludes::add)
+	    workspace.excludeDirs.stream()
+                .map(context.projectDir::resolve)
+                .forEach(topLevelModule.excludes::add)
         topLevelModule.excludes.add(context.projectDir.resolve(".idea"))
         topLevelModule.excludes.add(context.projectDir.resolve(".workspace_tool"))
         modules[topLevelModule.name] = topLevelModule

--- a/subprojects/intellij/src/main/groovy/net/covers1624/wt/intellij/api/impl/IntellijImpl.groovy
+++ b/subprojects/intellij/src/main/groovy/net/covers1624/wt/intellij/api/impl/IntellijImpl.groovy
@@ -16,7 +16,7 @@ import net.covers1624.wt.intellij.api.script.Intellij
 class IntellijImpl extends AbstractWorkspace implements Intellij {
 
     private String jdkName
-    private List<String> excludeDirs = new ArrayList<>()
+    private List<String> excludeDirs = new LinkedList<>()
 
     IntellijImpl(MixinInstantiator mixinInstantiator) {
         super(mixinInstantiator)

--- a/subprojects/intellij/src/main/groovy/net/covers1624/wt/intellij/api/impl/IntellijImpl.groovy
+++ b/subprojects/intellij/src/main/groovy/net/covers1624/wt/intellij/api/impl/IntellijImpl.groovy
@@ -16,6 +16,7 @@ import net.covers1624.wt.intellij.api.script.Intellij
 class IntellijImpl extends AbstractWorkspace implements Intellij {
 
     private String jdkName
+    private List<String> excludeDirs = new ArrayList<>()
 
     IntellijImpl(MixinInstantiator mixinInstantiator) {
         super(mixinInstantiator)
@@ -29,5 +30,15 @@ class IntellijImpl extends AbstractWorkspace implements Intellij {
     @Override
     String getJdkName() {
         return jdkName
+    }
+
+    @Override
+    void excludeDir(String path) {
+        excludeDirs.add(path)
+    }
+
+    @Override
+    List<String> getExcludeDirs() {
+        return excludeDirs
     }
 }

--- a/subprojects/intellij/src/main/groovy/net/covers1624/wt/intellij/api/script/Intellij.groovy
+++ b/subprojects/intellij/src/main/groovy/net/covers1624/wt/intellij/api/script/Intellij.groovy
@@ -19,4 +19,8 @@ trait Intellij implements Workspace {
     abstract void setJdkName(String name)
 
     abstract String getJdkName()
+
+    abstract void excludeDir(String path)
+
+    abstract List<String> getExcludeDirs()
 }


### PR DESCRIPTION
This pull request adds code to implement the feature requests from #5 & #6
Additionally all generated run config paths are registered as excluded directories

Additional exclude directories are specified within the `workspace` block using `excludeDir(String: path)`

The following is now valid for a `workspace.groovy` file

[See here](https://paste.md-5.net/kuvukuvezo.groovy) for the full `workspace.groovy` file
Sets up basic 1.19.2 workspace with sub project using the 1.19.2 MDK

```groovy
workspace(Intellij) {
	// excluding test folder within the root of the project
	excludeDir './test'

	runConfigs {
		'Client' {
			classpathModule 'ForgeRoot.forge.main'

			sysProp 'forge.logging.markers': ''
			sysProp 'forge.logging.console.level': 'debug'
			// passing a boolean value via Object#toString
			sysProp 'forge.enableGameTest': false

			// passing integer values via Object#toString
			progArg '--width', 1920
			progArg '--height', 1080

			mainClass 'net.covers1624.wt.OfflineLaunch'
			launchTarget 'forgeclientdev'

			runDir path('run/client')
			withShortClasspath()
		}
	}
}
```